### PR TITLE
Add missing ASRs to report

### DIFF
--- a/DefenderEval/DefenderEval-Report.psm1
+++ b/DefenderEval/DefenderEval-Report.psm1
@@ -424,9 +424,23 @@ Function Invoke-CheckDefenderRecommendations {
         $Results += New-Object -TypeName psobject -Property @{
             Topic="Exploit protection"
             Check="ASR Rule ($($ASR.ID))"
+            ASR=$ASR.ID
             Result=$Result
             Config=$ASRState
             Description=$ASRName
+        }
+    }
+
+    # Ensure that rows are added to the results if any defined ASR rules are missing
+    foreach ($ASRDefinition in $($ASRDefinitions.GetEnumerator())) {
+        if ($Results.ASR -notcontains $($ASRDefinition.Name)) {
+            $Results += New-Object -TypeName psobject -Property @{
+                Topic="Exploit protection"
+                Check="ASR Rule ($($ASRDefinition.Name))"
+                Result="No"
+                Config="Missing"
+                Description=$($ASRDefinition.Value)
+            }
         }
     }
 


### PR DESCRIPTION
Ensures rows still get added to the report if the ASR details don't exist in the output of Get-MpPreference

<img width="900" alt="image" src="https://github.com/user-attachments/assets/ec1bc204-f3a2-4c17-9319-967b390e8cd5" />


Previously they would not be included:
<img width="913" alt="image" src="https://github.com/user-attachments/assets/bf37be13-98c5-4a34-9acf-8fdc88a03f04" />

