### PR TITLE
Remove legacy function from list of exported functions by the module

### DIFF
--- a/DefenderEval/DefenderEval-Report.psm1
+++ b/DefenderEval/DefenderEval-Report.psm1
@@ -69,12 +69,6 @@ Function Invoke-ModuleVersionCheck {
     }
 }
 
-Function Invoke-CheckDefenderRecommendations {
-    Write-Warning "The command to run the report has been changed to 'Get-DefenderEvaluationReport'. Please run that command instead next time."
-
-    Get-DefenderEvaluationReport
-}
-
 Function Get-DefenderEvaluationReport {
     param (
 

--- a/DefenderEval/DefenderEval.psd1
+++ b/DefenderEval/DefenderEval.psd1
@@ -69,8 +69,7 @@ PowerShellVersion = '5.1'
 NestedModules = @('DefenderEval-Report.psm1')
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Invoke-CheckDefenderRecommendations', 
-               'Get-DefenderEvaluationReport'
+FunctionsToExport = 'Get-DefenderEvaluationReport'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
Remove the `Invoke-CheckDefenderRecommendations` function and remove from the list of functions exported by the module.